### PR TITLE
Correct name of example architecture rule

### DIFF
--- a/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/InterfaceRulesTest.java
+++ b/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/InterfaceRulesTest.java
@@ -26,7 +26,7 @@ public class InterfaceRulesTest {
             noClasses().that().areInterfaces().should().haveNameMatching(".*Interface");
 
     @ArchTest
-    public static final ArchRule interfaces_should_not_have_simple_class_names_ending_with_the_word_interface =
+    public static final ArchRule interfaces_should_not_have_simple_class_names_containing_the_word_interface =
             noClasses().that().areInterfaces().should().haveSimpleNameContaining("Interface");
 
     @ArchTest


### PR DESCRIPTION
Rule name and declaration did not match, therefore change the rule name.