### PR TITLE
Enable generate display name config

### DIFF
--- a/example-junit4/src/test/resources/archunit.properties
+++ b/example-junit4/src/test/resources/archunit.properties
@@ -1,1 +1,2 @@
 freeze.store.default.path=src/test/resources/frozen
+junit.displayName.replaceUnderscoresBySpaces=true

--- a/example-junit5/src/test/resources/archunit.properties
+++ b/example-junit5/src/test/resources/archunit.properties
@@ -1,1 +1,2 @@
 freeze.store.default.path=src/test/resources/frozen
+junit.displayName.replaceUnderscoresBySpaces=true

--- a/example-plain/src/test/resources/archunit.properties
+++ b/example-plain/src/test/resources/archunit.properties
@@ -1,3 +1,4 @@
 extension.archunit-example-extension.enabled=false
 extension.archunit-example-extension.example-prop=exampleValue
 freeze.store.default.path=src/test/resources/frozen
+junit.displayName.replaceUnderscoresBySpaces=true


### PR DESCRIPTION
Generate more readable names in the test report by replacing underscores in the original rule names by space