### PR TITLE
Support executing JUnit5 example tests from IntelliJ IDEA

### DIFF
--- a/example-junit5/build.gradle
+++ b/example-junit5/build.gradle
@@ -1,5 +1,9 @@
 dependencies {
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.2.1'
+
+    // ArchUnit does not actually need the JUnit Jupiter API,
+    // but some IDEs support executing tests more conveniently when it is present.
+    testCompileOnly 'org.junit.jupiter:junit-jupiter-api:5.10.1'
 }
 
 test {


### PR DESCRIPTION
IntelliJ IDEA did not offer to execute the `example-junit5` tests directly from the IDE,
but adding the `junit-jupiter-api` dependency changed this inconvenient behavior
(currently observed with IntelliJ IDEA 2023.2 and 2023.3.2):

![IntelliJ-IDEA_with_and_without_junit-jupiter-api](https://github.com/TNG/ArchUnit-Examples/assets/4208552/fd6766b3-e665-439c-93c7-15206536c972)
